### PR TITLE
Fix build errors

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -24,6 +24,14 @@ target_link_libraries(robarma_tests PRIVATE robarma Catch2::Catch2WithMain)
 enable_testing()
 add_test(NAME robarma_tests COMMAND robarma_tests)
 
+# Custom 'tests' target for convenience
+add_custom_target(tests
+    COMMAND ${CMAKE_CTEST_COMMAND} --output-on-failure
+    DEPENDS robarma_tests
+    WORKING_DIRECTORY ${CMAKE_BINARY_DIR}
+    COMMENT "Build and run all tests"
+)
+
 # Install rules (optional)
 install(DIRECTORY include/ DESTINATION include)
 install(TARGETS robarma EXPORT robarmaTargets)

--- a/include/arma.hpp
+++ b/include/arma.hpp
@@ -15,6 +15,7 @@
 #pragma once
 
 #include <Eigen/Dense>
+#include <iomanip>
 #include <alias.hpp>
 #include <bip.hpp>
 #include <estimation_result.hpp>

--- a/include/estimation_result.hpp
+++ b/include/estimation_result.hpp
@@ -14,6 +14,7 @@
 #pragma once
 
 #include <iostream>
+#include <iomanip>
 #include <array>
 
 namespace robarma


### PR DESCRIPTION
Few build errors were raised when trying to create a Python-wrapper. This PR corresponds to those. 

- Include <iomanip> in arma.hpp and estimation_result.hpp
- Include custom target for tests