### PR TITLE
Use bip-arma residuals (bug) and Ceres optimizations

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,25 +65,3 @@ arma_fit fit = robarma::estimators::mm(arma);
 std::cout << fit << std::endl;
 
 ```
-
-Giving
-
-```bash
-ARMA estimation summary
-
-Initial values
-
-phi
-theta     0.1994  -0.3889
-mu        2.0038
-
-estimation method   MM
-convergence         TRUE
-final cost          0.4844
-
-Estimated parameters
-
-phi
-theta     0.2077  -0.3899
-mu        1.9982
-```

--- a/docs/doxygen-awesome/DOXY_MAINPAGE.md
+++ b/docs/doxygen-awesome/DOXY_MAINPAGE.md
@@ -63,15 +63,4 @@ robarma::arma arma(y, 0, 2);
 
 arma_fit fit = robarma::estimators::mm(arma);
 std::cout << fit << std::endl;
-
-```
-
-This gives
-
-```bash
-ARMA fit
-
-phi
-theta    -0.1814   0.4219
-mu        1.9941
 ```

--- a/include/bip_s.hpp
+++ b/include/bip_s.hpp
@@ -54,7 +54,6 @@ namespace robarma::estimators
         auto *cost_function = new ceres::DynamicAutoDiffCostFunction<bip_s_functor, 4>(new bip_s_functor(model));
 
         ceres::Solver::Options options;
-
         options.minimizer_type = ceres::LINE_SEARCH;
 
         arma_fit fit = robarma::solver::solve(model, initial, estimation_method::bs, cost_function, options);

--- a/include/bip_s.hpp
+++ b/include/bip_s.hpp
@@ -55,7 +55,6 @@ namespace robarma::estimators
 
         ceres::Solver::Options options;
 
-        options.max_num_iterations = 100;
         options.minimizer_type = ceres::LINE_SEARCH;
 
         arma_fit fit = robarma::solver::solve(model, initial, estimation_method::bs, cost_function, options);

--- a/include/bmm.hpp
+++ b/include/bmm.hpp
@@ -38,7 +38,6 @@ namespace robarma::bmm
         auto *cost_function = new ceres::DynamicAutoDiffCostFunction<cost, 4>(new cost(model, sigma));
 
         ceres::Solver::Options options;
-        options.max_num_iterations = 100;
 
         arma_fit fit = robarma::solver::solve(model, initial, estimation_method::bmm, cost_function, options);
 

--- a/include/bmm.hpp
+++ b/include/bmm.hpp
@@ -25,7 +25,7 @@ namespace robarma::bmm
         {
             auto [phi, theta, mu] = model.get_params(parameters);
 
-            Vec<T> e = model.arma_residuals(phi, theta, mu) / T(sigma);
+            Vec<T> e = model.bip_arma_residuals(phi, theta, mu, T(sigma)) / T(sigma);
 
             T est = robarma::bip::rho2(e).sum();
             residuals[0] = est;

--- a/include/bmm.hpp
+++ b/include/bmm.hpp
@@ -37,11 +37,8 @@ namespace robarma::bmm
     {
         auto *cost_function = new ceres::DynamicAutoDiffCostFunction<cost, 4>(new cost(model, sigma));
 
-        // Run the solver!
         ceres::Solver::Options options;
-
         options.max_num_iterations = 100;
-        options.minimizer_type = ceres::LINE_SEARCH;
 
         arma_fit fit = robarma::solver::solve(model, initial, estimation_method::bmm, cost_function, options);
 

--- a/include/estimation_result.hpp
+++ b/include/estimation_result.hpp
@@ -58,7 +58,7 @@ namespace robarma
      * Contains:
      *  - method: which estimation method was used
      *  - convergence: whether the optimizer converged
-     *  - final_cost: objective function value
+     *  - final_cost: objective function value (as we return only one value, Ceres gives the correct value, not squared one)
      *  - report: (optional) optimizer report string
      *
      * Used in arma_fit to track both initial and final estimation results.

--- a/include/estimators.hpp
+++ b/include/estimators.hpp
@@ -73,7 +73,6 @@ namespace robarma::estimators
         auto *cost_function = new ceres::DynamicAutoDiffCostFunction<mle::cost, 4>(new mle::cost(model));
 
         ceres::Solver::Options options;
-        options.max_num_iterations = 100;
 
         arma_fit fit = robarma::solver::solve(model, initial, estimation_method::mle, cost_function, options);
 
@@ -96,7 +95,6 @@ namespace robarma::estimators
         auto *cost_function = new ceres::DynamicAutoDiffCostFunction<ftau::cost, 4>(new ftau::cost(model));
 
         ceres::Solver::Options options;
-        options.max_num_iterations = 100;
 
         arma_fit fit = robarma::solver::solve(model, initial, estimation_method::ftau, cost_function, options);
 
@@ -119,7 +117,6 @@ namespace robarma::estimators
 
         // Unstable without line_search
         ceres::Solver::Options options;
-        options.max_num_iterations = 100;
         options.minimizer_type = ceres::LINE_SEARCH;
 
         arma_fit fit = robarma::solver::solve(model, initial, estimation_method::s, cost_function, options);
@@ -144,7 +141,6 @@ namespace robarma::estimators
         auto *cost_function = new ceres::DynamicAutoDiffCostFunction<mm::cost, 4>(new mm::cost(model, sigma));
 
         ceres::Solver::Options options;
-        options.max_num_iterations = 100;
 
         arma_fit fit = robarma::solver::solve(model, initial, estimation_method::mm, cost_function, options);
 

--- a/include/estimators.hpp
+++ b/include/estimators.hpp
@@ -158,7 +158,6 @@ namespace robarma::estimators
     arma_fit bip_mm(const arma_model &model)
     {
         // Step 1.
-
         arma_fit s_mm = robarma::estimators::s(model);
         arma_fit s_bmm = robarma::estimators::bip_s(model);
 
@@ -166,7 +165,6 @@ namespace robarma::estimators
         double sigma = fmin(s_mm.result.final_cost, s_bmm.result.final_cost);
 
         // Step 3.
-
         arma_fit fit_mm = robarma::mm::mm(model, sigma, s_mm);
         arma_fit fit_bmm = robarma::bmm::bmm(model, sigma, s_bmm);
 

--- a/include/estimators.hpp
+++ b/include/estimators.hpp
@@ -51,7 +51,6 @@ namespace robarma::estimators
 
         // With trust-region minimizer, every solution is equal to initial estimate of Hannan-Rissanen.
         ceres::Solver::Options options;
-        options.logging_type = ceres::SILENT;
         options.minimizer_type = ceres::LINE_SEARCH;
 
         arma_fit fit = robarma::solver::solve(model, initial, estimation_method::ols, cost_function, options);
@@ -75,7 +74,6 @@ namespace robarma::estimators
 
         ceres::Solver::Options options;
         options.max_num_iterations = 100;
-        options.logging_type = ceres::SILENT;
 
         arma_fit fit = robarma::solver::solve(model, initial, estimation_method::mle, cost_function, options);
 
@@ -97,9 +95,7 @@ namespace robarma::estimators
 
         auto *cost_function = new ceres::DynamicAutoDiffCostFunction<ftau::cost, 4>(new ftau::cost(model));
 
-        // Run the solver!
         ceres::Solver::Options options;
-
         options.max_num_iterations = 100;
 
         arma_fit fit = robarma::solver::solve(model, initial, estimation_method::ftau, cost_function, options);
@@ -121,11 +117,9 @@ namespace robarma::estimators
 
         auto *cost_function = new ceres::DynamicAutoDiffCostFunction<s::cost, 4>(new s::cost(model));
 
-        // Run the solver!
-        ceres::Solver::Options options;
-
-        options.max_num_iterations = 100;
         // Unstable without line_search
+        ceres::Solver::Options options;
+        options.max_num_iterations = 100;
         options.minimizer_type = ceres::LINE_SEARCH;
 
         arma_fit fit = robarma::solver::solve(model, initial, estimation_method::s, cost_function, options);
@@ -149,11 +143,8 @@ namespace robarma::estimators
 
         auto *cost_function = new ceres::DynamicAutoDiffCostFunction<mm::cost, 4>(new mm::cost(model, sigma));
 
-        // Run the solver!
         ceres::Solver::Options options;
-
         options.max_num_iterations = 100;
-        // options.minimizer_type = ceres::LINE_SEARCH;
 
         arma_fit fit = robarma::solver::solve(model, initial, estimation_method::mm, cost_function, options);
 

--- a/include/mm.hpp
+++ b/include/mm.hpp
@@ -36,11 +36,8 @@ namespace robarma::mm
     {
         auto *cost_function = new ceres::DynamicAutoDiffCostFunction<cost, 4>(new cost(model, sigma));
 
-        // Run the solver!
         ceres::Solver::Options options;
-
         options.max_num_iterations = 100;
-        options.minimizer_type = ceres::LINE_SEARCH;
 
         arma_fit fit = robarma::solver::solve(model, initial, estimation_method::mm, cost_function, options);
 

--- a/include/mm.hpp
+++ b/include/mm.hpp
@@ -24,7 +24,7 @@ namespace robarma::mm
         bool operator()(T const *const *parameters, T *residuals) const
         {
             auto [phi, theta, mu] = model.get_params(parameters);
-            // std::cout << phi << theta << mu << std::endl;
+
             Vec<T> e = model.arma_residuals(phi, theta, mu) / T(sigma);
             T est = robarma::bip::rho2(e).sum() / T(model.n - model.p);
             residuals[0] = est;

--- a/include/mm.hpp
+++ b/include/mm.hpp
@@ -37,7 +37,6 @@ namespace robarma::mm
         auto *cost_function = new ceres::DynamicAutoDiffCostFunction<cost, 4>(new cost(model, sigma));
 
         ceres::Solver::Options options;
-        options.max_num_iterations = 100;
 
         arma_fit fit = robarma::solver::solve(model, initial, estimation_method::mm, cost_function, options);
 

--- a/include/solver.hpp
+++ b/include/solver.hpp
@@ -34,7 +34,7 @@ namespace robarma::solver
      * @return arma_fit containing the optimized parameters and results
      */
     template <typename T>
-    arma_fit solve(const arma_model &model, const arma_fit initial, estimation_method method, ceres::DynamicAutoDiffCostFunction<T> *cost_function, const ceres::Solver::Options options)
+    arma_fit solve(const arma_model &model, const arma_fit initial, estimation_method method, ceres::DynamicAutoDiffCostFunction<T> *cost_function, ceres::Solver::Options options)
     {
         arma_fit opt_params = initial;
 


### PR DESCRIPTION
Fixes bad bug of not using BIP-ARMA residuals in BMM-estimation step. Remove unnecesseray max_num_iterations options. Specify use cases for line search algorithms. 