### PR TITLE
Solve compiler errors

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,6 +8,15 @@ find_package(Ceres REQUIRED)
 find_package(Catch2 3 REQUIRED)
 
 # Header-only library target
+if(APPLE)
+    if (CMAKE_CXX_COMPILER_ID STREQUAL "Clang")
+        execute_process(COMMAND ${CMAKE_CXX_COMPILER} --version OUTPUT_VARIABLE CLANG_VERSION)
+        string(FIND "${CLANG_VERSION}" "Apple" APPLE_CLANG_FOUND)
+        if (APPLE_CLANG_FOUND EQUAL -1)
+            message(WARNING "You are building with non-Apple Clang on macOS. This may cause linker/ABI errors. It is recommended to use Apple Clang for all dependencies and your project.")
+        endif()
+    endif()
+endif()
 add_library(robarma INTERFACE)
 target_compile_features(robarma INTERFACE cxx_std_17)
 target_include_directories(robarma INTERFACE

--- a/include/arma.hpp
+++ b/include/arma.hpp
@@ -20,6 +20,7 @@
 #include <bip.hpp>
 #include <estimation_result.hpp>
 #include <robust.hpp>
+#include <optional>
 
 namespace robarma
 {

--- a/include/bip_s.hpp
+++ b/include/bip_s.hpp
@@ -46,7 +46,7 @@ namespace robarma::estimators
         };
     };
 
-    arma_fit bip_s(const arma_model &model)
+    inline arma_fit bip_s(const arma_model &model)
     {
         // Calculate the initial S-estimator for ARMA model
         arma_fit initial = robarma::initial::hannan_rissanen(model);

--- a/include/bmm.hpp
+++ b/include/bmm.hpp
@@ -33,7 +33,7 @@ namespace robarma::bmm
         };
     };
 
-    arma_fit bmm(const arma_model &model, const double &sigma, arma_fit &initial)
+    inline arma_fit bmm(const arma_model &model, const double &sigma, arma_fit &initial)
     {
         auto *cost_function = new ceres::DynamicAutoDiffCostFunction<cost, 4>(new cost(model, sigma));
 

--- a/include/estimators.hpp
+++ b/include/estimators.hpp
@@ -43,7 +43,7 @@ namespace robarma::estimators
      * @param model
      * @return arma_fit
      */
-    arma_fit ols(const arma_model &model)
+    inline arma_fit ols(const arma_model &model)
     {
         arma_fit initial = robarma::initial::hannan_rissanen(model);
 
@@ -66,7 +66,7 @@ namespace robarma::estimators
      * @param model
      * @return arma_fit
      */
-    arma_fit mle(const arma_model &model)
+    inline arma_fit mle(const arma_model &model)
     {
         arma_fit initial = robarma::initial::hannan_rissanen(model);
 
@@ -88,7 +88,7 @@ namespace robarma::estimators
      * @param model
      * @return arma_fit
      */
-    arma_fit ftau(const arma_model &model)
+    inline arma_fit ftau(const arma_model &model)
     {
         arma_fit initial = robarma::initial::hannan_rissanen(model);
 
@@ -109,7 +109,7 @@ namespace robarma::estimators
      * @param model
      * @return arma_fit
      */
-    arma_fit s(const arma_model &model)
+    inline arma_fit s(const arma_model &model)
     {
         arma_fit initial = robarma::initial::hannan_rissanen(model);
 
@@ -132,7 +132,7 @@ namespace robarma::estimators
      * @param model
      * @return arma_fit
      */
-    arma_fit mm(const arma_model &model)
+    inline arma_fit mm(const arma_model &model)
     {
         arma_fit initial = robarma::estimators::s(model);
 
@@ -155,7 +155,7 @@ namespace robarma::estimators
      * @param model
      * @return arma_fit
      */
-    arma_fit bip_mm(const arma_model &model)
+    inline arma_fit bip_mm(const arma_model &model)
     {
         // Step 1.
         arma_fit s_mm = robarma::estimators::s(model);

--- a/include/hr.hpp
+++ b/include/hr.hpp
@@ -17,7 +17,7 @@ namespace robarma::initial
      * @param model
      * @return arma_fit
      */
-    arma_fit hannan_rissanen(arma_model model)
+    inline arma_fit hannan_rissanen(arma_model model)
     {
         // Step 1: Fit an AR(M)-model to data
         double mu = model.y.mean();

--- a/include/mm.hpp
+++ b/include/mm.hpp
@@ -32,7 +32,7 @@ namespace robarma::mm
         };
     };
 
-    arma_fit mm(const arma_model &model, const double &sigma, arma_fit &initial)
+    inline arma_fit mm(const arma_model &model, const double &sigma, arma_fit &initial)
     {
         auto *cost_function = new ceres::DynamicAutoDiffCostFunction<cost, 4>(new cost(model, sigma));
 

--- a/include/robust.hpp
+++ b/include/robust.hpp
@@ -6,7 +6,7 @@
 namespace robarma::base
 {
     template <typename Derived>
-    typename Derived::Scalar median(Eigen::DenseBase<Derived> &d)
+    inline typename Derived::Scalar median(Eigen::DenseBase<Derived> &d)
     {
         auto r{d.reshaped()};
         std::sort(r.begin(), r.end());
@@ -14,7 +14,7 @@ namespace robarma::base
     }
 
     template <typename Derived>
-    typename Derived::Scalar median(const Eigen::DenseBase<Derived> &d)
+    inline typename Derived::Scalar median(const Eigen::DenseBase<Derived> &d)
     {
         typename Derived::PlainObject m{d.replicate(1, 1)};
         return median(m);
@@ -22,7 +22,7 @@ namespace robarma::base
 
     // Median Absolute deviation
     template <typename T>
-    T MAD(const Vec<T> &x)
+    inline T MAD(const Vec<T> &x)
     {
 
         T med = median(x);
@@ -32,14 +32,14 @@ namespace robarma::base
 
     // Normalized MAD
     template <typename T>
-    T MADN(const Vec<T> &x)
+    inline T MADN(const Vec<T> &x)
     {
         return MAD(x) / T(0.675);
     }
 
     // Huber psi-function for an Eigen vector
     template <typename T>
-    Vec<T> huber(const Vec<T> &x, T k = T(1.345))
+    inline Vec<T> huber(const Vec<T> &x, T k = T(1.345))
     {
         return x.unaryExpr([k](const T &xi)
                            {
@@ -50,7 +50,7 @@ namespace robarma::base
     }
 
     template <typename T>
-    T bisquare(const T x, T k = T(1.547645))
+    inline T bisquare(const T x, T k = T(1.547645))
     {
         // eff 95%, k = 4.685 for location
         // maximum breakdown of 50%, k = 1.547645 for scale
@@ -65,15 +65,15 @@ namespace robarma::base
     }
 
     template <typename T>
-    Vec<T> bisquare(const Vec<T> x, const T k)
+    inline Vec<T> bisquare(const Vec<T> x, const T k)
     {
         return x.unaryExpr([k](const T &xi)
                            { return bisquare(xi, k); });
     }
 
     template <typename T>
-    T scale(const Vec<T> x, const T b = T(0.5), std::function<Vec<T>(Vec<T>)> func = [](const Vec<T> &v)
-                                                { return bisquare(v, T(1.547645)); })
+    inline T scale(const Vec<T> x, const T b = T(0.5), std::function<Vec<T>(Vec<T>)> func = [](const Vec<T> &v)
+                                                       { return bisquare(v, T(1.547645)); })
     {
         T tol = T(1e-6);
         T err = T(1) + tol;

--- a/include/simulate.hpp
+++ b/include/simulate.hpp
@@ -14,6 +14,7 @@ namespace robarma
 {
 
     bool stationary(const Eigen::VectorXd &ar)
+    inline bool stationary(const Eigen::VectorXd &ar)
     {
         Eigen::PolynomialSolver<double, Eigen::Dynamic> solver;
         Eigen::VectorXd coeff = Eigen::VectorXd(ar.size() + 1);
@@ -23,7 +24,7 @@ namespace robarma
         return (roots.array().abs() > 1.0).all();
     }
 
-    bool invertible(const Eigen::VectorXd &ma)
+    inline bool invertible(const Eigen::VectorXd &ma)
     {
         Eigen::PolynomialSolver<double, Eigen::Dynamic> solver;
         Eigen::VectorXd coeff = Eigen::VectorXd(ma.size() + 1);

--- a/include/simulate.hpp
+++ b/include/simulate.hpp
@@ -12,8 +12,6 @@
 
 namespace robarma
 {
-
-    bool stationary(const Eigen::VectorXd &ar)
     inline bool stationary(const Eigen::VectorXd &ar)
     {
         Eigen::PolynomialSolver<double, Eigen::Dynamic> solver;

--- a/include/tau.hpp
+++ b/include/tau.hpp
@@ -13,7 +13,7 @@
 namespace robarma::tau
 {
     template <typename T>
-    T rho1(const T x)
+    inline T rho1(const T x)
     {
         T c = T(1.55);
         T div = x / c;
@@ -29,13 +29,13 @@ namespace robarma::tau
     }
 
     template <typename T>
-    Vec<T> rho1(const Vec<T> x)
+    inline Vec<T> rho1(const Vec<T> x)
     {
         return x.unaryExpr(static_cast<T (*)(const T)>(&rho1));
     }
 
     template <typename T>
-    T rho2(const T x)
+    inline T rho2(const T x)
     {
         T c = T(2.8);
 
@@ -50,26 +50,26 @@ namespace robarma::tau
     }
 
     template <typename T>
-    Vec<T> rho2(const Vec<T> x)
+    inline Vec<T> rho2(const Vec<T> x)
     {
         return x.unaryExpr(static_cast<T (*)(const T)>(&rho2));
     }
 
     template <typename T>
-    T psi(T x)
+    inline T psi(T x)
     {
         T c = T(1.55);
         return (ceres::abs(x) < c) ? x : T(0);
     }
 
     template <typename T>
-    T w(T x)
+    inline T w(T x)
     {
         return psi<T>(x) / (x + std::numeric_limits<T>::epsilon());
     }
 
     template <typename T>
-    T s(Vec<T> u)
+    inline T s(Vec<T> u)
     {
         // Assume that u is a vector of residuals
         std::function<Vec<T>(Vec<T>)> func = static_cast<Vec<T> (*)(const Vec<T>)>(&rho1);
@@ -77,7 +77,7 @@ namespace robarma::tau
     }
 
     template <typename T>
-    T tau(Vec<T> u)
+    inline T tau(Vec<T> u)
     {
         T sn = s(u);
         return sn * sqrt(rho2((u / sn).eval()).mean());

--- a/include/ts.hpp
+++ b/include/ts.hpp
@@ -14,7 +14,7 @@ namespace robarma
 {
 
     template <typename T>
-    Mat<T> robust_autocov_matrix(const Vec<T> &y, const int &m, const int &n)
+    inline Mat<T> robust_autocov_matrix(const Vec<T> &y, const int &m, const int &n)
     {
         int N = y.size();
         T med = robarma::base::median(y);
@@ -44,7 +44,7 @@ namespace robarma
 
     // Sample autocovariance matrix of size m x n
     template <typename T>
-    Mat<T> autocov_matrix(const Vec<T> &y, const int &m, const int &n)
+    inline Mat<T> autocov_matrix(const Vec<T> &y, const int &m, const int &n)
     {
         int N = y.size();
         T avg = y.mean();
@@ -71,7 +71,7 @@ namespace robarma
     }
 
     template <typename T>
-    Vec<T> causal(Vec<T> phi, Vec<T> theta)
+    inline Vec<T> causal(Vec<T> phi, Vec<T> theta)
     {
         // Calculate coefficients for characteristic polynomial of causal representation
         // lambda(B) = theta(B) / phi(B)


### PR DESCRIPTION
- Add inline definition to free functions.
- Add warning for non-Mac compiler on MacOS. 

For example, if user has built Ceres on Homebrew (which would use default clang), one should also built this project using the same compiler. 