### PR TITLE
Add clang-tidy and clang-format

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,1 @@
+BasedOnStyle: Microsoft

--- a/.clang-format
+++ b/.clang-format
@@ -1,1 +1,10 @@
-BasedOnStyle: Microsoft
+UseTab: Never
+IndentWidth: 4
+TabWidth: 4
+BreakBeforeBraces: Allman
+AllowShortIfStatementsOnASingleLine: false
+IndentCaseLabels: false
+ColumnLimit: 0
+AccessModifierOffset: -4
+FixNamespaceComments: true
+NamespaceIndentation: All

--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,4 +1,4 @@
-Checks: '-*,modernize-*,performance-*,bugprone-*,readability-*,cppcoreguidelines-*, misc-*, clang-analyzer-*'
+Checks: '-*,performance-*,bugprone-*,readability-*,cppcoreguidelines-*, misc-*, clang-analyzer-*'
 WarningsAsErrors: ''
-HeaderFilterRegex: '^(include/|tests/)'
+HeaderFilterRegex: '.*'
 FormatStyle: none

--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,0 +1,4 @@
+Checks: '-*,modernize-*,performance-*,bugprone-*,readability-*,cppcoreguidelines-*, misc-*, clang-analyzer-*'
+WarningsAsErrors: ''
+HeaderFilterRegex: '^(include/|tests/)'
+FormatStyle: none

--- a/include/arma.hpp
+++ b/include/arma.hpp
@@ -15,12 +15,12 @@
 #pragma once
 
 #include <Eigen/Dense>
-#include <iomanip>
 #include <alias.hpp>
 #include <bip.hpp>
 #include <estimation_result.hpp>
-#include <robust.hpp>
+#include <iomanip>
 #include <optional>
+#include <robust.hpp>
 
 namespace robarma
 {
@@ -209,5 +209,5 @@ namespace robarma
             return os;
         };
     };
-}
+} // namespace robarma
 // end of file

--- a/include/bip.hpp
+++ b/include/bip.hpp
@@ -1,8 +1,8 @@
 #pragma once
 
 #include <Eigen/Dense>
-#include <ceres/ceres.h>
 #include <alias.hpp>
+#include <ceres/ceres.h>
 
 /**
  * @brief Rho functions used in MM-, BIP-MM and S-estimators as defined in \cite Muler
@@ -67,5 +67,5 @@ namespace robarma::bip
     {
         return x.unaryExpr(static_cast<T (*)(const T)>(&eta));
     }
-}
+} // namespace robarma::bip
 // end of file

--- a/include/bip_s.hpp
+++ b/include/bip_s.hpp
@@ -1,11 +1,11 @@
 #pragma once
 
-#include <arma.hpp>
-#include <ceres/ceres.h>
 #include <Eigen/Dense>
-#include <hr.hpp>
 #include <alias.hpp>
+#include <arma.hpp>
 #include <bip.hpp>
+#include <ceres/ceres.h>
+#include <hr.hpp>
 #include <robust.hpp>
 #include <ts.hpp>
 
@@ -59,5 +59,5 @@ namespace robarma::estimators
         arma_fit fit = robarma::solver::solve(model, initial, estimation_method::bs, cost_function, options);
         return fit;
     }
-}
+} // namespace robarma::estimators
 // end of file

--- a/include/bip_s.hpp
+++ b/include/bip_s.hpp
@@ -7,6 +7,7 @@
 #include <ceres/ceres.h>
 #include <hr.hpp>
 #include <robust.hpp>
+#include <solver.hpp>
 #include <ts.hpp>
 
 namespace robarma::estimators

--- a/include/bmm.hpp
+++ b/include/bmm.hpp
@@ -1,8 +1,8 @@
 #pragma once
 
-#include <arma.hpp>
 #include <Eigen/Dense>
 #include <alias.hpp>
+#include <arma.hpp>
 #include <bip.hpp>
 #include <solver.hpp>
 
@@ -44,5 +44,5 @@ namespace robarma::bmm
         return fit;
     }
 
-}
+} // namespace robarma::bmm
 // end of file

--- a/include/estimation_result.hpp
+++ b/include/estimation_result.hpp
@@ -13,9 +13,9 @@
  */
 #pragma once
 
-#include <iostream>
-#include <iomanip>
 #include <array>
+#include <iomanip>
+#include <iostream>
 
 namespace robarma
 {
@@ -116,6 +116,6 @@ namespace robarma
         };
     };
 
-}
+} // namespace robarma
 
 // end of file

--- a/include/estimators.hpp
+++ b/include/estimators.hpp
@@ -17,14 +17,14 @@
 #include <hr.hpp>
 #include <solver.hpp>
 
-#include <ols.hpp>
-#include <mle.hpp>
-#include <ftau.hpp>
-#include <s.hpp>
-#include <mm.hpp>
-#include <bmm.hpp>
 #include <bip_s.hpp>
+#include <bmm.hpp>
 #include <estimation_result.hpp>
+#include <ftau.hpp>
+#include <mle.hpp>
+#include <mm.hpp>
+#include <ols.hpp>
+#include <s.hpp>
 
 /**
  * @namespace robarma::estimators
@@ -173,6 +173,6 @@ namespace robarma::estimators
 
         return (m < mb) ? fit_mm : fit_bmm;
     }
-}
+} // namespace robarma::estimators
 
 // end of file

--- a/include/ftau.hpp
+++ b/include/ftau.hpp
@@ -2,6 +2,7 @@
 
 #include <alias.hpp>
 #include <arma.hpp>
+#include <state_space_cost.hpp>
 #include <tau.hpp>
 
 namespace robarma::ftau

--- a/include/ftau.hpp
+++ b/include/ftau.hpp
@@ -1,7 +1,7 @@
 #pragma once
 
-#include <arma.hpp>
 #include <alias.hpp>
+#include <arma.hpp>
 #include <tau.hpp>
 
 namespace robarma::ftau
@@ -68,5 +68,5 @@ namespace robarma::ftau
             return true;
         }
     };
-}
+} // namespace robarma::ftau
 // end of file

--- a/include/hr.hpp
+++ b/include/hr.hpp
@@ -1,7 +1,7 @@
 #pragma once
 
-#include <arma.hpp>
 #include <Eigen/Dense>
+#include <arma.hpp>
 #include <estimation_result.hpp>
 
 /**
@@ -64,4 +64,4 @@ namespace robarma::initial
 
         return arma_fit(model, arma_params(phi, theta, mu), result);
     }
-}
+} // namespace robarma::initial

--- a/include/logging.hpp
+++ b/include/logging.hpp
@@ -17,4 +17,4 @@ namespace robarma
         }
 #endif
     }
-}
+} // namespace robarma

--- a/include/mle.hpp
+++ b/include/mle.hpp
@@ -1,7 +1,7 @@
 #pragma once
 
-#include <arma.hpp>
 #include <alias.hpp>
+#include <arma.hpp>
 #include <state_space_cost.hpp>
 
 namespace robarma::mle
@@ -70,5 +70,5 @@ namespace robarma::mle
         };
     };
 
-}
+} // namespace robarma::mle
 // end of file

--- a/include/mm.hpp
+++ b/include/mm.hpp
@@ -1,8 +1,8 @@
 #pragma once
 
-#include <arma.hpp>
 #include <Eigen/Dense>
 #include <alias.hpp>
+#include <arma.hpp>
 #include <bip.hpp>
 #include <solver.hpp>
 
@@ -42,5 +42,5 @@ namespace robarma::mm
 
         return fit;
     }
-}
+} // namespace robarma::mm
 // end of file

--- a/include/ols.hpp
+++ b/include/ols.hpp
@@ -1,8 +1,8 @@
 #pragma once
 
-#include <arma.hpp>
 #include <Eigen/Dense>
 #include <alias.hpp>
+#include <arma.hpp>
 #include <solver.hpp>
 
 namespace robarma::ols
@@ -26,5 +26,5 @@ namespace robarma::ols
             return true;
         };
     };
-}
+} // namespace robarma::ols
 // end of file

--- a/include/robust.hpp
+++ b/include/robust.hpp
@@ -94,6 +94,6 @@ namespace robarma::base
         }
         return sigma_0;
     }
-}
+} // namespace robarma::base
 
 // end of file

--- a/include/s.hpp
+++ b/include/s.hpp
@@ -1,8 +1,8 @@
 #pragma once
 
-#include <arma.hpp>
 #include <Eigen/Dense>
 #include <alias.hpp>
+#include <arma.hpp>
 #include <bip.hpp>
 #include <robust.hpp>
 
@@ -32,5 +32,5 @@ namespace robarma::s
             return true;
         };
     };
-}
+} // namespace robarma::s
 // end of file

--- a/include/simulate.hpp
+++ b/include/simulate.hpp
@@ -7,8 +7,8 @@
 #pragma once
 
 #include <Eigen/Dense>
-#include <unsupported/Eigen/Polynomials>
 #include <EigenRand/EigenRand>
+#include <unsupported/Eigen/Polynomials>
 
 namespace robarma
 {
@@ -130,6 +130,6 @@ namespace robarma
         }
         return x.tail(n);
     }
-}
+} // namespace robarma
 
 // end of file

--- a/include/solver.hpp
+++ b/include/solver.hpp
@@ -71,6 +71,6 @@ namespace robarma::solver
         arma_fit fit(model, params, result, initial.params, initial.result);
         return fit;
     }
-}
+} // namespace robarma::solver
 
 // end of file

--- a/include/tau.hpp
+++ b/include/tau.hpp
@@ -83,5 +83,5 @@ namespace robarma::tau
         return sn * sqrt(rho2((u / sn).eval()).mean());
     }
 
-}
+} // namespace robarma::tau
 // end of file

--- a/include/ts.hpp
+++ b/include/ts.hpp
@@ -6,8 +6,8 @@
 #pragma once
 
 #include <Eigen/Dense>
-#include <arma.hpp>
 #include <alias.hpp>
+#include <arma.hpp>
 #include <robust.hpp>
 
 namespace robarma
@@ -95,6 +95,6 @@ namespace robarma
         return lambda.tail(n - 1);
     }
 
-}
+} // namespace robarma
 
 // end of file

--- a/tests/test_main.cpp
+++ b/tests/test_main.cpp
@@ -1,18 +1,18 @@
-#include <catch2/catch_test_macros.hpp>
-#include <iostream>
-#include <simulate.hpp>
 #include <Eigen/Dense>
 #include <arma.hpp>
-#include <estimators.hpp>
-#include <mle.hpp>
-#include <ftau.hpp>
-#include <s.hpp>
-#include <mm.hpp>
 #include <bip_s.hpp>
-#include <tau.hpp>
+#include <catch2/catch_test_macros.hpp>
 #include <ceres/ceres.h>
-#include <ts.hpp>
+#include <estimators.hpp>
+#include <ftau.hpp>
+#include <iostream>
+#include <mle.hpp>
+#include <mm.hpp>
 #include <robust.hpp>
+#include <s.hpp>
+#include <simulate.hpp>
+#include <tau.hpp>
+#include <ts.hpp>
 
 TEST_CASE("ARMA TEST", "[arma]")
 {


### PR DESCRIPTION
Add clang-tidy and clang-format to project as development tools. Format files with same style formatter as before, small additions. Use Visual Studio style formatting for clang-tidy.